### PR TITLE
Upgrade to finagle 6.31 and make Java 7 compatible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,9 @@ resolvers += "twttr" at "http://maven.twttr.com/"
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
-  "com.twitter"    %% "finagle-core"    % "6.28.0",
-  "com.twitter"    %% "finagle-httpx"   % "6.28.0",
-  "org.json4s"     %% "json4s-jackson"  % "3.2.11",
-  "org.scalatest"  %% "scalatest"       % "2.2.4"   % "test"
+  "commons-codec"  %  "commons-codec"  % "1.9",
+  "com.twitter"    %% "finagle-core"   % "6.31.0",
+  "com.twitter"    %% "finagle-http"   % "6.31.0",
+  "org.json4s"     %% "json4s-jackson" % "3.2.11",
+  "org.scalatest"  %% "scalatest"      % "2.2.4"   % "test"
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")

--- a/src/main/scala/com/github/dmexe/finagle/consul/ConsulErrors.scala
+++ b/src/main/scala/com/github/dmexe/finagle/consul/ConsulErrors.scala
@@ -1,6 +1,6 @@
 package com.github.dmexe.finagle.consul
 
-import com.twitter.finagle.httpx.Response
+import com.twitter.finagle.http.Response
 
 object ConsulErrors {
   class BadResponseException(msg: String) extends RuntimeException(msg)

--- a/src/main/scala/com/github/dmexe/finagle/consul/ConsulHttpClientFactory.scala
+++ b/src/main/scala/com/github/dmexe/finagle/consul/ConsulHttpClientFactory.scala
@@ -1,7 +1,7 @@
 package com.github.dmexe.finagle.consul
 
-import com.twitter.finagle.httpx.{Request, Response}
-import com.twitter.finagle.{Httpx, Service}
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Http, Service}
 
 import scala.collection.mutable
 
@@ -14,7 +14,7 @@ object ConsulHttpClientFactory {
   def getClient(hosts: String): Client = {
     synchronized {
       val client = clients.getOrElseUpdate(hosts, {
-        Httpx.newService(hosts)
+        Http.newService(hosts)
       })
       client
     }

--- a/src/main/scala/com/github/dmexe/finagle/consul/ConsulLeaderElection.scala
+++ b/src/main/scala/com/github/dmexe/finagle/consul/ConsulLeaderElection.scala
@@ -4,7 +4,7 @@ import java.util.logging.{Level, Logger}
 
 import com.github.dmexe.finagle.consul.client.KeyService
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{Request, Response}
+import com.twitter.finagle.http.{Request, Response}
 import com.twitter.util._
 
 class ConsulLeaderElection(name: String, httpClient: Service[Request,Response], session: ConsulSession) {

--- a/src/main/scala/com/github/dmexe/finagle/consul/ConsulService.scala
+++ b/src/main/scala/com/github/dmexe/finagle/consul/ConsulService.scala
@@ -2,13 +2,13 @@ package com.github.dmexe.finagle.consul
 
 import java.util.logging.Logger
 import com.github.dmexe.finagle.consul.client.KeyService
-import com.twitter.finagle.httpx.{Request, Response}
-import com.twitter.finagle.{Service => HttpxService}
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Service => HttpService}
 import com.twitter.util.Await
 
 import scala.collection.mutable
 
-class ConsulService(httpClient: HttpxService[Request, Response]) {
+class ConsulService(httpClient: HttpService[Request, Response]) {
 
   import ConsulService._
 

--- a/src/main/scala/com/github/dmexe/finagle/consul/ConsulSession.scala
+++ b/src/main/scala/com/github/dmexe/finagle/consul/ConsulSession.scala
@@ -5,7 +5,7 @@ import java.util.logging.{Level, Logger}
 
 import com.github.dmexe.finagle.consul.client.SessionService
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{Request, Response}
+import com.twitter.finagle.http.{Request, Response}
 import com.twitter.util.{Await, NonFatal, Return, Throw, Try}
 
 class ConsulSession(httpClient: Service[Request, Response], opts: ConsulSession.Options) {

--- a/src/main/scala/com/github/dmexe/finagle/consul/client/KeyService.scala
+++ b/src/main/scala/com/github/dmexe/finagle/consul/client/KeyService.scala
@@ -1,14 +1,14 @@
 package com.github.dmexe.finagle.consul.client
 
-import java.util.Base64
 import com.github.dmexe.finagle.consul.ConsulErrors
-import com.twitter.finagle.httpx.{Method, Request => HttpRequest, Response => HttpResponse}
-import com.twitter.finagle.{Service => HttpxService}
+import com.twitter.finagle.http.{Method, Request => HttpRequest, Response => HttpResponse}
+import com.twitter.finagle.{Service => HttpService}
 import com.twitter.util.Future
+import org.apache.commons.codec.binary.Base64
 import org.json4s.jackson.JsonMethods._
 import org.json4s.jackson.Serialization
 
-class KeyService(httpClient: HttpxService[HttpRequest, HttpResponse]) {
+class KeyService(httpClient: HttpService[HttpRequest, HttpResponse]) {
 
   import KeyService._
 
@@ -156,7 +156,7 @@ class KeyService(httpClient: HttpxService[HttpRequest, HttpResponse]) {
   }
 
   private def decodeStringValue(bytes: String): String = {
-    new String(Base64.getDecoder.decode(bytes))
+    new String(Base64.decodeBase64(bytes))
   }
 
   private def keyName(path: String, recurse: Boolean = false, acquire: Option[String] = None, release: Option[String] = None): String = {
@@ -190,5 +190,5 @@ class KeyService(httpClient: HttpxService[HttpRequest, HttpResponse]) {
 object KeyService {
   case class Response[T](Session: Option[String], CreateIndex: Int, ModifyIndex: Int, LockIndex: Int, Key: String, Flags: Int, Value: T)
 
-  def apply(httpClient: HttpxService[HttpRequest, HttpResponse]) = new KeyService(httpClient)
+  def apply(httpClient: HttpService[HttpRequest, HttpResponse]) = new KeyService(httpClient)
 }

--- a/src/main/scala/com/github/dmexe/finagle/consul/client/SessionService.scala
+++ b/src/main/scala/com/github/dmexe/finagle/consul/client/SessionService.scala
@@ -1,13 +1,13 @@
 package com.github.dmexe.finagle.consul.client
 
 import com.github.dmexe.finagle.consul.ConsulErrors
-import com.twitter.finagle.httpx.{Method, Request => HttpRequest, Response => HttpResponse}
-import com.twitter.finagle.{Service => HttpxService}
+import com.twitter.finagle.http.{Method, Request => HttpRequest, Response => HttpResponse}
+import com.twitter.finagle.{Service => HttpService}
 import com.twitter.util.Future
 import org.json4s.jackson.JsonMethods._
 import org.json4s.jackson.Serialization
 
-class SessionService(httpClient: HttpxService[HttpRequest, HttpResponse]) {
+class SessionService(httpClient: HttpService[HttpRequest, HttpResponse]) {
   import SessionService._
 
   implicit val format = org.json4s.DefaultFormats
@@ -65,5 +65,5 @@ object SessionService {
   case class CreateResponse(ID: String)
   case class SessionResponse(LockDelay: Int, Checks: Set[String], Node: String, ID: String, CreateIndex: Int, Behavior: String, TTL: String)
 
-  def apply(httpClient: HttpxService[HttpRequest, HttpResponse]) = new SessionService(httpClient)
+  def apply(httpClient: HttpService[HttpRequest, HttpResponse]) = new SessionService(httpClient)
 }


### PR DESCRIPTION
java.util.Base64 doesn't exist in Java 7, so I use commons-codec
instead. I also make the changes needed for finagle 6.31
(httpx => http).
